### PR TITLE
Fix markdown link text in ja/support/index.md

### DIFF
--- a/docs/ja/support/index.md
+++ b/docs/ja/support/index.md
@@ -14,7 +14,7 @@
 
 ## Issue Tracker
 
-上記の手順で問題を解決できなかった場合は、issue tracker](https://github.com/Elringus/NaninovelWeb/issues?q=is%3Aissue+label%3Abug) を確認してください。すでにその問題に取り組んでいるかもしれません。
+上記の手順で問題を解決できなかった場合は、[issue tracker](https://github.com/Elringus/NaninovelWeb/issues?q=is%3Aissue+label%3Abug) を確認してください。すでにその問題に取り組んでいるかもしれません。
 
 ## コミュニティフォーラム
 


### PR DESCRIPTION
Thank you for supporting Japanese! 😂 

The markdown link was broken, so I fixed it.

# before

![スクリーンショット 2020-07-12 13 33 41](https://user-images.githubusercontent.com/1044064/87238958-5587ba00-c444-11ea-8369-d9ca9a49ef30.png)

# after

![スクリーンショット 2020-07-12 13 33 35](https://user-images.githubusercontent.com/1044064/87238969-6e906b00-c444-11ea-9197-e0ba178fbdce.png)

